### PR TITLE
Cast media with media_play service

### DIFF
--- a/custom_components/samsungtv_custom/media_player.py
+++ b/custom_components/samsungtv_custom/media_player.py
@@ -33,6 +33,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_STEP,
     SUPPORT_VOLUME_SET,
     MEDIA_TYPE_APP,
+    MEDIA_TYPE_URL,
 )
 from homeassistant.const import (
     CONF_HOST,
@@ -448,6 +449,22 @@ class SamsungTVDevice(MediaPlayerDevice):
                 return
 
             await self.hass.async_add_job(self.send_command, media_id)
+
+        # Play media
+        elif media_type == MEDIA_TYPE_URL:
+            try:
+                cv.url(media_id)
+            except vol.Invalid:
+                _LOGGER.error('Media ID must be an url (ex: "http://"')
+                return
+
+            self._remote.set_current_media(media_id)
+            self._playing = True
+
+        # Trying to make stream component work on TV
+        elif media_type == "application/vnd.apple.mpegurl":
+            self._remote.set_current_media(media_id)
+            self._playing = True
 
         else:
             _LOGGER.error("Unsupported media type")

--- a/custom_components/samsungtv_custom/samsungtvws/remote.py
+++ b/custom_components/samsungtv_custom/samsungtvws/remote.py
@@ -220,20 +220,20 @@ class SamsungTVWS:
 
             for app in self._app_list:
 
-              r = None
+                r = None
 
-              try:
-                r = requests.get('http://{host}:8001/api/v2/applications/{value}'.format(host=self.host, value=self._app_list[app]), timeout=0.5)
-              except requests.exceptions.RequestException as e:
-                pass
+                try:
+                    r = requests.get('http://{host}:8001/api/v2/applications/{value}'.format(host=self.host, value=self._app_list[app]), timeout=0.5)
+                except requests.exceptions.RequestException as e:
+                    pass
 
-              if r is not None:
-                  data = r.text
-                  if data is not None:
-                      root = json.loads(data.encode('UTF-8'))
-                      if 'visible' in root:
-                        if root['visible']:
-                            return app
+                if r is not None:
+                    data = r.text
+                    if data is not None:
+                        root = json.loads(data.encode('UTF-8'))
+                        if 'visible' in root:
+                            if root['visible']:
+                                return app
 
         return 'TV/HDMI'
 
@@ -253,3 +253,18 @@ class SamsungTVWS:
             else:
                 self.mute = True
         return self.mute
+
+    def set_current_media(self, url):
+        """ Set media to playback and play it."""
+        try:
+            self.SOAPrequest('SetAVTransportURI', "<CurrentURI>{url}</CurrentURI><CurrentURIMetaData></CurrentURIMetaData>".format(url=url), 'AVTransport')
+            self.SOAPrequest('Play', "<Speed>1</Speed>", 'AVTransport')
+        except Exception:
+            pass
+
+    def play(self):
+        """ Play media that was already set as current."""
+        try:
+            self.SOAPrequest('Play', "<Speed>1</Speed>", 'AVTransport')
+        except Exception:
+            pass


### PR DESCRIPTION
Cast music or video to the TV
Need further tests to determine all compatible file types

**Example**
`service: media_player.play_media`
```
{
  "entity_id": "media_player.samsungtv",
  "media_content_type": "url",
  "media_content_id": "FILE_URL",
}
```
_Replace FILE_URL with the url of your file._

I tried to make it work with the camera  stream service but I never managed to play it on the TV. The video codec may not be compatible with samsung TVs. If someone has an idea I still included it in my code.